### PR TITLE
feat/#42 Blocking 방식으로 WebSocketSession 동시성 문제 해결

### DIFF
--- a/src/main/java/com/project/game/websocket/WebSocketSessionManager.java
+++ b/src/main/java/com/project/game/websocket/WebSocketSessionManager.java
@@ -9,25 +9,23 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
-
-// TODO Thread 정보로 session을 식별하는 Thread Local를 통해서 Thread ID마다 Connection ID를 담아둬서 Connection ID를 활용하자.
 @Component
 public class WebSocketSessionManager {
 
     private Map<Long, WebSocketSession> webSocketSessionMap = new ConcurrentHashMap<>();
 
-    public void addWebSocketSessionMap(Long key, WebSocketSession socketSession) {
+    public synchronized void addWebSocketSessionMap(Long key, WebSocketSession socketSession) {
         if (!validateSession(socketSession)) {
             throw new WebSocketSessionInvalidException();
         }
         this.webSocketSessionMap.put(key, socketSession);
     }
 
-    public void removeWebSocketSessionMap(Long key) {
+    public synchronized void removeWebSocketSessionMap(Long key) {
         this.webSocketSessionMap.remove(key);
     }
 
-    public void sendMessage(String message, List<Long> keys) throws IOException {
+    public synchronized void sendMessage(String message, List<Long> keys) throws IOException {
         for (Long key : keys) {
             WebSocketSession socketSession = this.webSocketSessionMap.get(key);
             if (validateSession(socketSession)) {
@@ -36,7 +34,7 @@ public class WebSocketSessionManager {
         }
     }
 
-    public boolean validateSession(WebSocketSession socketSession) {
+    public synchronized boolean validateSession(WebSocketSession socketSession) {
         return socketSession != null && socketSession.isOpen();
     }
 }

--- a/src/main/java/com/project/game/websocket/handler/WebSocketMessageHandler.java
+++ b/src/main/java/com/project/game/websocket/handler/WebSocketMessageHandler.java
@@ -49,7 +49,6 @@ public class WebSocketMessageHandler extends TextWebSocketHandler {
         Long characterId = null;
         try {
             characterId = extractCharacterId(session, Long.class);
-            // TODO JSON 파싱 시 Protocol 전체를 한번에 파싱하는 클래스 or 메서드를 만들자?
             JsonObject jsonObject = jsonUtil.fromJson(message.getPayload(), JsonObject.class);
             Long matchId = jsonUtil.extractProperty(jsonObject, MATCH_ID, Long.class);
             JsonObject request = jsonUtil.extractProperty(jsonObject, REQUEST, JsonObject.class);
@@ -117,6 +116,11 @@ public class WebSocketMessageHandler extends TextWebSocketHandler {
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         // TODO 강제 종료에 대한 처리 필요 (ex match room 관리, match 결과에 대한 처리, reconnection 시 어떻게 처리할 것인지 등)
-        webSocketSessionManager.removeWebSocketSessionMap(extractCharacterId(session, Long.class));
+        try (session) {
+            webSocketSessionManager.removeWebSocketSessionMap(
+                extractCharacterId(session, Long.class));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
### 개요
API 테스트를 통해 동시성 문제점 발견
``` Java
    @GetMapping("/ws/run")
    public ResponseEntity<?> run() throws IOException {
        IntStream.range(2, 100)
            .forEach(n -> new Thread(() -> {
                webSocketSessionManager.addWebSocketSessionMap(
                    (long) n, new StandardWebSocketSession(null, null, null, null));
            }).start());

        webSocketSessionManager.sendMessage(webSocketSessionManager.getSessionSize(),
            Collections.singletonList(1L));
        webSocketSessionManager.clearSession();
        return ResponseEntity.ok().build();
    }
```

###해결
- [ ] synchronized 키워드를 통해 WebSocket session 동시성 문제 해결
- [ ] 추후 synchronized 대체 방법 고려
``` Java
public synchronized void sendMessage(String message, List<Long> keys) throws IOException {
        for (Long key : keys) {
            WebSocketSession socketSession = this.webSocketSessionMap.get(key);
            if (validateSession(socketSession)) {
                socketSession.sendMessage(new TextMessage(message));
            }
        }
    }
```