### PR TITLE
feat/#42 WebSocket 메세지 프로토콜 전용 DTO를 통해 메세지 파싱 관리하도록 수정

### DIFF
--- a/src/main/java/com/project/game/common/util/JsonUtil.java
+++ b/src/main/java/com/project/game/common/util/JsonUtil.java
@@ -1,10 +1,15 @@
 package com.project.game.common.util;
 
+import static com.project.game.websocket.constant.WebSocketMessageProtocol.COMMAND;
+import static com.project.game.websocket.constant.WebSocketMessageProtocol.MATCH_ID;
+import static com.project.game.websocket.constant.WebSocketMessageProtocol.REQUEST;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.project.game.common.exception.ValueInvalidException;
 import com.project.game.websocket.constant.WebSocketMessageProtocol;
+import com.project.game.websocket.dto.WebSocketMessageRequest;
 import lombok.Getter;
 import org.springframework.stereotype.Component;
 
@@ -24,8 +29,13 @@ public class JsonUtil {
         return gson.fromJson(jsonElement, clazz);
     }
 
-    public <T> T fromJson(String payload, Class<T> jsonObjectClass) {
-        return gson.fromJson(payload, jsonObjectClass);
+    public WebSocketMessageRequest parseWebSocketMessage(String payload) {
+        JsonObject jsonObject = gson.fromJson(payload, JsonObject.class);
+        Long matchId = extractProperty(jsonObject, MATCH_ID, Long.class);
+        JsonObject request = extractProperty(jsonObject, REQUEST, JsonObject.class);
+        String command = extractProperty(jsonObject, COMMAND, String.class);
+
+        return new WebSocketMessageRequest(matchId, request, command);
     }
 
     public <T> T fromJson(JsonElement jsonElement, Class<T> jsonObjectClass) {

--- a/src/main/java/com/project/game/websocket/constant/WebSocketCommand.java
+++ b/src/main/java/com/project/game/websocket/constant/WebSocketCommand.java
@@ -18,7 +18,7 @@ public enum WebSocketCommand {
         this.command = command;
     }
 
-    public static WebSocketCommand findByCommand(String command) {
+    public static WebSocketCommand findWebSocketCommand(String command) {
         return Arrays.stream(WebSocketCommand.values())
             .filter(webSocketCommand -> command.equals(webSocketCommand.command))
             .findAny()

--- a/src/main/java/com/project/game/websocket/dto/WebSocketMessageRequest.java
+++ b/src/main/java/com/project/game/websocket/dto/WebSocketMessageRequest.java
@@ -1,0 +1,7 @@
+package com.project.game.websocket.dto;
+
+import com.google.gson.JsonObject;
+
+public record WebSocketMessageRequest(Long matchId, JsonObject request, String command) {
+
+}


### PR DESCRIPTION
###Before
``` Java
            JsonObject jsonObject = jsonUtil.fromJson(message.getPayload(), JsonObject.class);
            Long matchId = jsonUtil.extractProperty(jsonObject, MATCH_ID, Long.class);
            JsonObject request = jsonUtil.extractProperty(jsonObject, REQUEST, JsonObject.class);
            String command = jsonUtil.extractProperty(jsonObject, COMMAND, String.class);
```

###After
``` Java
           WebSocketMessageRequest messageRequest = jsonUtil.parseWebSocketMessage(message.getPayload());
            Long matchId = messageRequest.matchId();
            JsonObject request = messageRequest.request();
            String command = messageRequest.command();
```